### PR TITLE
Update & improve nonce handling

### DIFF
--- a/src/Extensions/ControllerExtension.php
+++ b/src/Extensions/ControllerExtension.php
@@ -24,31 +24,31 @@ class ControllerExtension extends Extension
     public function onAfterInit()
     {
 
-        // Don't go in a loop reporting to the Reporting Endpoint controller from the Reporting Endpoint controller!
-        if ($this->owner instanceof ReportingEndpoint) {
-            return;
-        }
-
-        // check if we can proceed
-        if (!Policy::checkCanApply()) {
-            return;
-        }
-
+        // No response handling
         $response = $this->owner->getResponse();
         if ($response && !($response instanceof HTTPResponse)) {
             return;
         }
 
-        $stage = Versioned::get_stage();
+        // Don't go in a loop reporting to the Reporting Endpoint controller from the Reporting Endpoint controller!
+        if ($this->owner instanceof ReportingEndpoint) {
+            return;
+        }
+
+        // check if a policy can be applied
+        if (!$canApply = Policy::checkCanApply($this->owner)) {
+            return;
+        }
 
         // check if request on the Live stage
+        $stage = Versioned::get_stage();
         $is_live = ($stage == Versioned::LIVE);
 
         // only get enabled policy/directives
         $enabled_policy = $enabled_directives = true;
 
-        // set a CSP nonce for this request
-        $nonce = new Nonce();
+        // Set the CSP nonce for this request
+        Nonce::getNonce();
 
         $policy = Policy::getDefaultBasePolicy($is_live, Policy::POLICY_DELIVERY_METHOD_HEADER);
 

--- a/src/Extensions/SiteTreeExtension.php
+++ b/src/Extensions/SiteTreeExtension.php
@@ -74,15 +74,14 @@ class SiteTreeExtension extends Extension
      */
     private function checkCanRun()
     {
-        $whitelisted_controllers = Config::inst()->get(Policy::class, 'whitelisted_controllers');
-        $controller = Controller::curr();
+        $controller = Controller::has_curr() ? Controller::curr() : false;
         if (!$controller) {
             // no current controller
             return false;
         }
 
-        if (is_array($whitelisted_controllers) && in_array(get_class($controller), $whitelisted_controllers)) {
-            // allow through without MetaTags
+        // Configured controllers with no CSP
+        if(Policy::controllerWithoutCsp($controller)) {
             return false;
         }
 

--- a/src/Models/Nonce.php
+++ b/src/Models/Nonce.php
@@ -64,22 +64,20 @@ class Nonce
      * @return void
      */
     public static function addToAttributes(string $tag, array &$attributes) {
-        if(Policy::checkCanApply()) {
-            // inline scripts and style tags get the nonce
-            switch($tag) {
-                case 'script':
-                    if(!empty($attributes['src'])) {
-                        // no nonce
-                        break;
-                    }
-                    // else
-                case 'style':
-                    $attributes['nonce'] = self::getNonce();
-                    break;
-                default:
+        // inline scripts and style tags get the nonce
+        switch($tag) {
+            case 'script':
+                if(!empty($attributes['src'])) {
                     // no nonce
                     break;
-            }
+                }
+                // else
+            case 'style':
+                $attributes['nonce'] = self::getNonce();
+                break;
+            default:
+                // no nonce
+                break;
         }
     }
 

--- a/src/Models/Nonce.php
+++ b/src/Models/Nonce.php
@@ -7,7 +7,10 @@ use SilverStripe\View\Requirements;
 
 /**
  * Model handling creation and retrieval of a nonce
- * @author james.ellis@dpc.nsw.gov.au
+ *
+ * To create the nonce or get the current nonce value, call Nonce::getNonce()
+ *
+ * @author james
  */
 class Nonce
 {
@@ -18,11 +21,6 @@ class Nonce
     private static $nonce = '';
 
     const MIN_LENGTH = 16;
-
-    /**
-     * To create the nonce or get the current nonce value, call Nonce::getNonce()
-     */
-    private function __construct() {}
 
     /**
      * Create a nonce

--- a/src/Models/Nonce.php
+++ b/src/Models/Nonce.php
@@ -17,35 +17,20 @@ class Nonce
      */
     private static $nonce = '';
 
-    /**
-     * @var int
-     */
-    private static $length;
-
     const MIN_LENGTH = 16;
 
     /**
-     * @param boolean $recreate force recreation of a nonce, this is generally only used in tests
+     * To create the nonce or get the current nonce value, call Nonce::getNonce()
      */
-    public function __construct($recreate = false) {
-        $length = intval(Config::inst()->get( Policy::class, 'nonce_length'));
-        if($length < self::MIN_LENGTH) {
-            $length = self::MIN_LENGTH;
-        }
-        if($recreate) {
-            self::$nonce = '';
-        }
-        self::$length = $length;
-        self::create();
-    }
+    private function __construct() {}
 
     /**
      * Create a nonce
      * @return void
      */
-    private static function create()
+    private static function create($length)
     {
-        self::$nonce = bin2hex(random_bytes(self::$length / 2));
+        self::$nonce = bin2hex(random_bytes($length / 2));
     }
 
     /**
@@ -53,7 +38,25 @@ class Nonce
      * @return string
      */
     public static function getNonce() : string {
+        // Return existing nonce
+        if(self::$nonce) {
+            return self::$nonce;
+        }
+        // Create the nonce
+        $length = intval(Config::inst()->get( Policy::class, 'nonce_length'));
+        if($length < self::MIN_LENGTH) {
+            $length = self::MIN_LENGTH;
+        }
+        self::create($length);
         return self::$nonce;
+    }
+
+    /**
+     * Clear the nonce value
+     * This is only used in tests
+     */
+    public static function clear() {
+        self::$nonce = '';
     }
 
     /**
@@ -95,7 +98,7 @@ class Nonce
             }
             if(self::applicableElement($domElement)) {
                 $textContent = htmlspecialchars($domElement->textContent);
-                $domElement->setAttribute('nonce', self::$nonce);
+                $domElement->setAttribute('nonce', self::getNonce());
             }
         }
     }

--- a/src/Models/Policy.php
+++ b/src/Models/Policy.php
@@ -77,7 +77,7 @@ class Policy extends DataObject implements PermissionProvider
 
     /**
      * Set to true to override the result of  self::checkCanApply()
-     * @var boolean
+     * @var bool
      */
     private static $override_apply = false;
 
@@ -626,16 +626,10 @@ class Policy extends DataObject implements PermissionProvider
 
     /**
      * Check if the policy can be applied based on configuration and the state of the current request
+     * @param Controller the controller to check against, if not supplied the current controller is used
      * @return bool
      */
-    public static function checkCanApply(Controller $controller = null) : bool {
-
-        if(!$controller) {
-            if(!Controller::has_curr()) {
-                return false;
-            }
-            $controller = Controller::curr();
-        }
+    public static function checkCanApply(Controller $controller) : bool {
 
         $override = Config::inst()->get(Policy::class, 'override_apply');
         if($override) {

--- a/tests/MiddlewarePolicyFunctionalTest.php
+++ b/tests/MiddlewarePolicyFunctionalTest.php
@@ -4,6 +4,8 @@ namespace NSWDPC\Utilities\ContentSecurityPolicy\Tests;
 
 use NSWDPC\Utilities\ContentSecurityPolicy\Policy;
 
+require_once(dirname(__FILE__) . '/AbstractPolicyFunctionalTest.php');
+
 /**
  * Functional test using Middleware as the nonce injection solution
  */

--- a/tests/NonceTest.php
+++ b/tests/NonceTest.php
@@ -10,16 +10,29 @@ use SilverStripe\Dev\SapphireTest;
 
 class NonceTest extends SapphireTest {
 
+    public function setUp() {
+        parent::setUp();
+        // clear nonce for each test
+        Nonce::clear();
+    }
+
+    public function testNonceStaysTheSame() {
+        Config::inst()->update( Policy::class, 'nonce_length', Nonce::MIN_LENGTH);
+        $nonce = Nonce::getNonce();
+        $this->assertNotEmpty($nonce, "Nonce is empty");
+        $nonce2 = Nonce::getNonce();
+        $this->assertEquals($nonce, $nonce2, "Nonce should remain the same");
+    }
+
     public function testShortNonce() {
         $min_length = Nonce::MIN_LENGTH;
         // set an 8 chr nonce length
         $length = round($min_length / 2);
         Config::inst()->update( Policy::class, 'nonce_length', $length);
-        $nonce = new Nonce(true);
-        $this->assertNotEmpty(Nonce::getNonce(), "Nonce is empty");
+        $nonce = Nonce::getNonce();
+        $this->assertNotEmpty($nonce, "Nonce is empty");
         // nonce should be a minimum of 32 chrs
-        $value = Nonce::getNonce();
-        $this->assertNotEquals(strlen($value), $length, "Nonce should not be {$length} chrs, {$min_length} chr minimum");
+        $this->assertNotEquals(strlen($nonce), $length, "Nonce should not be {$length} chrs, {$min_length} chr minimum");
     }
 
     public function testExactLengthNonce() {
@@ -28,10 +41,9 @@ class NonceTest extends SapphireTest {
         // set a $min_length chr nonce length
         $length = $min_length;
         Config::inst()->update( Policy::class, 'nonce_length', $length);
-        $nonce = new Nonce(true);
-        $this->assertNotEmpty(Nonce::getNonce(), "Nonce is empty");
-        $value = Nonce::getNonce();
-        $this->assertEquals(strlen($value), $length, "Nonce should be {$length} chrs");
+        $nonce = Nonce::getNonce();
+        $this->assertNotEmpty($nonce, "Nonce is empty");
+        $this->assertEquals(strlen($nonce), $length, "Nonce should be {$length} chrs");
 
     }
 
@@ -41,10 +53,9 @@ class NonceTest extends SapphireTest {
         // set a $min_length chr nonce length
         $length = ($min_length * 2);
         Config::inst()->update( Policy::class, 'nonce_length', $length);
-        $nonce = new Nonce(true);
-        $this->assertNotEmpty(Nonce::getNonce(), "Nonce is empty");
-        $value = Nonce::getNonce();
-        $this->assertEquals(strlen($value), $length, "Nonce should not be {$length} chrs");
+        $nonce = Nonce::getNonce();
+        $this->assertNotEmpty($nonce, "Nonce is empty");
+        $this->assertEquals(strlen($nonce), $length, "Nonce should not be {$length} chrs");
 
     }
 
@@ -66,11 +77,10 @@ class NonceTest extends SapphireTest {
             'media' => 'screen'
         ];
 
-        $nonce = new Nonce(true);
-        $nonceValue = Nonce::getNonce();
+        $nonce = Nonce::getNonce();
         Nonce::addToAttributes('style', $attributes);
 
         $this->assertTrue( array_key_exists('nonce', $attributes) );
-        $this->assertEquals( $nonceValue, $attributes['nonce'] );
+        $this->assertEquals( $nonce, $attributes['nonce'] );
     }
 }

--- a/tests/NonceTest.php
+++ b/tests/NonceTest.php
@@ -64,13 +64,15 @@ class NonceTest extends SapphireTest {
      */
     public function testApplyAttributes() {
 
+        $controller = Controller::curr();
+
         Config::inst()->update( Policy::class, 'override_apply', false);
 
-        $this->assertFalse( Policy::checkCanApply(), 'Policy should NOT be applicable' );
+        $this->assertFalse( Policy::checkCanApply($controller), 'Policy should NOT be applicable' );
 
         Config::inst()->update( Policy::class, 'override_apply', true);
 
-        $this->assertTrue( Policy::checkCanApply(), 'Policy should be applicable' );
+        $this->assertTrue( Policy::checkCanApply($controller), 'Policy should be applicable' );
 
         $attributes = [
             'type' => 'text/css',

--- a/tests/PolicyFunctionalTest.php
+++ b/tests/PolicyFunctionalTest.php
@@ -4,6 +4,8 @@ namespace NSWDPC\Utilities\ContentSecurityPolicy\Tests;
 
 use NSWDPC\Utilities\ContentSecurityPolicy\Policy;
 
+require_once(dirname(__FILE__) . '/AbstractPolicyFunctionalTest.php');
+
 /**
  * Functional test using Requirements)_Backend as the nonce injection solution
  */


### PR DESCRIPTION
## Changes

+ Refactor how the nonce is created - calling `Nonce::getNonce()` returns the value (and creates one if none is available).
+ The controller parameter for Policy::checkCanApply is now required. This fixes an issue where  the current controller was not necessarily the controller calling the method, causing nonce recreation (#5)
+ Abstract handling of controllers allowed to drop the CSP into single method `controllerWithoutCsp`