### PR TITLE
Reporting headers

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -6,11 +6,13 @@ NSWDPC\Utilities\ContentSecurityPolicy\Policy:
   nonce_length: 16
   # or 'middleware'
   nonce_injection_method: 'requirements'
-  include_report_to: false
   run_in_modeladmin: false
-  max_age: 10886400
+  max_age: 3600
   include_subdomains: true
   whitelisted_controllers: []
+NSWDPC\Utilities\ContentSecurityPolicy\ReportingEndpoint:
+  # by default, do not accept local reports
+  accept_reports: false
 # report removal job
 NSWDPC\Utilities\ContentSecurityPolicy\PruneViolationReportsJob:
   older_than: 1

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,15 @@
     ],
     "autoload": {
         "psr-4": {
-            "NSWDPC\\Utilities\\ContentSecurityPolicy\\": "src/"
+            "NSWDPC\\Utilities\\ContentSecurityPolicy\\": [
+                "src/Controllers",
+                "src/Extensions",
+                "src/Jobs",
+                "src/Middleware",
+                "src/Models",
+                "src/Services/",
+                "src/Traits"
+            ]
         }
     },
     "autoload-dev": {

--- a/docs/en/00_index.md
+++ b/docs/en/00_index.md
@@ -4,32 +4,19 @@
 
 ### Configuration
 
-The default configuration for the module is as-folows (with inline comments)
+The default configuration can be found in  `_config/config.yml` and set on [a per-environment basis](https://docs.silverstripe.org/en/5/developer_guides/configuration/configuration/#before-after-rules)
 
-```yaml
+```yml
 ---
-Name: csp_configuration
+Name: app-csp-config
+After:
+  - '#csp_configuration'
 ---
 NSWDPC\Utilities\ContentSecurityPolicy\Policy:
-  # the length of the nonce attribute value, 16 should be considered the minimum
-  nonce_length: 16
-  # how to inject the nonce - via a 'requirements' backend or via 'middleware' (see below)
-  nonce_injection_method: 'requirements'
-  # where to send reports to a URL/Service
-  include_report_to: false
-  # whether to deliver the CSP in LeftAndMain controllers (not recommended at the moment)
-  run_in_modeladmin: false
-  # the maximum time a browser should send warning reports to a Reporting endpoint
-  max_age: 10886400
-  # include all subdomains of the domain when reporting errors
-  include_subdomains: true
-  # an array of controller classnames that can bypass a CSP
-  # confusing naming to be updated in a future release
-  whitelisted_controllers: []
-NSWDPC\Utilities\ContentSecurityPolicy\PruneViolationReportsJob:
-  # remove internally collected reports older than this amount of HOURS
-  older_than: 1
+  # reduce the max_age value
+  max_age: 120
 ```
+
 
 #### About the `nonce_injection_method`
 
@@ -46,23 +33,32 @@ As an administrator, you can modify the members who have access to this by assig
 
 > Anyone who can edit your the Policy and Directives can modify the CSP restrictions in place
 
-### Policy Options
-
-+ **Title** - add a human readable title, only used in the admin
-+ **Enabled** - turn the policy on/off
-+ **Minimum CSP Level** - 1, 2 or 3
-+ **Use on published website** - when checked, the policy will be available on Live stage requests. You can use this to test a policy on the Draft stage only
-+ **Is Base Policy** - check to make this the site-wide policy
-+ **Report Only** - adds the header "Content-Security-Policy-Report-Only", the policy will report to the browser's dev console and log to an endpoint if you have one configured. Reporting is not available when using meta tags to deliver CSP rules.
-+ **Send violation reports** - when checked, adds the Report-To header and report-uri directive to the policy
-+ **Set a reporting URL** - add the reporting URL for logging violations, this can be left empty to report back to the website (not recommended). You can add, for instance, a report-uri.com logging URL here.
-+ **Enable Network Error Logging (NEL)** - turned on Network Error Logging via the NEL header
-+ **Set an NEL/Reporting API reporting URL** - adds the NEL logging URL to the Report-To header
-+ **Delivery Method** -  Via an HTTP header (recommended) or a metatag. The module may remove the Metatag option in the future to simplify code.
+### Policy
 
 To start with, add a policy with the "Enabled" box unchecked. Once the policy is configured you can then add directives to it.
 
-Once a policy with directives is saved, an example of the policy will display.
++ **Title** - add a human readable title, only used in the admin
+
+#### Policy Options
+
++ **Enabled** - turn the policy on/off
++ **Minimum CSP Level** - 1, 2 or 3. Setting this value to 3 will turn off the "report-uri" directive
++ **Use on published website** - when checked, the policy will be available on Live stage requests. You can use this to test a policy on the Draft stage only
++ **Is Base Policy** - check to make this the site-wide policy
+
+#### CSP Reporting
+
++ **Send violation reports** - when checked, adds the Report-To header and report-uri directive to the policy
++ **Report Only** - adds the header "Content-Security-Policy-Report-Only", the policy will report to the browser's dev console and log to an endpoint if you have one configured. Reporting is not available when using meta tags to deliver CSP rules.
++ **Endpoint for report-uri violation reports** - add the reporting URL for logging violations, this can be left empty to report back to the website (not recommended). You can add, for instance, a report-uri.com logging URL here.
++ **Endpoint for Reporting API (report-to) violation reports** - add a URL for handling Reporting API reports. Some services have separate CSP reporting endpoints for report-uri and report-to.
+
+#### NEL Reporting
++ **Set an NEL/Reporting API reporting URL** - adds the NEL logging URL to the Report-To header. You must use an external service for this.
++ **Enable Network Error Logging (NEL)** - turned on Network Error Logging via the NEL header
+
+### Delivery options
++ **Delivery Method** -  Via an HTTP header (recommended) or a metatag. The module may remove the Metatag option in the future to simplify code.
 
 ### Adding Directives
 
@@ -88,10 +84,11 @@ The value of the directive will be the URLs and other rules that make up the all
 
 In this section add extra values for the directives in the left field. The right field can be used for your own notes/reasoning for the rule, and to aid with historical context.
 
-
 ### Violation Reports
 
-You can choose to report policy violations to your own website. This is not recommended if you have a high traffic website and your policy is causing lots of reports. It can be used in a development/testing environment to fine tune a report.
+You can choose to report policy violations to your own website (turned off by default).
+
+This is not recommended if you have a high traffic website and your policy is causing lots of reports. It can be used in a development/testing environment to fine tune a report.
 
 In production you can use a reporting tool such as report-uri.com to handle report collection.
 

--- a/docs/en/01_good_to_know.md
+++ b/docs/en/01_good_to_know.md
@@ -15,6 +15,8 @@ You can whitelist certain controllers in module config. This will block the poli
 
 ## Using meta tags
 
+> This option will be removed in v1.0
+
 You can choose to deliver the CSP via meta tags.
 
 Choosing this option will cause certain features to be unavailable

--- a/docs/en/02_browser_support.md
+++ b/docs/en/02_browser_support.md
@@ -1,12 +1,5 @@
 ## Browser support
 
-According to Can I Use, [CSP Level 1](https://caniuse.com/#feat=contentsecuritypolicy) is supported by about 92% of the browser population.
-
-Notable exceptions are Internet Explorer 10 and 11, which only support the ```sandbox``` directive.
-
-All versions of Internet Explorer are end-of-life and this module will not support CSP.
+According to Can I Use, [CSP Level 1](https://caniuse.com/#feat=contentsecuritypolicy) is supported by > 97% of browsers
 
 [CSP Level 2](https://caniuse.com/#feat=contentsecuritypolicy2) is supported by nearly all modern browsers, with the following exceptions:
-
-+ Firefox is missing the ```plugin-types``` directive
-+ [Edge non-Chromium has broken nonce support](https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/13246371/)

--- a/docs/en/05_reporturi_and_other_services.md
+++ b/docs/en/05_reporturi_and_other_services.md
@@ -2,38 +2,28 @@
 
 You can choose to receive violation reports when they occur at a reporting service that can handle CSP reports.
 
-The module provides its own controller for receiving violation reports - be aware that enabling local reporting could cause load issues on higher traffic websites.
-
-There are a number of external services that can be used to collect CSP reports, one example is report-uri.com.
-
 > NSWDPC does not make any service recommendations, this information is provided as a guide only and you are free to use whichever service you find suitable.
 
-### Configuring Report URI
+### Using a reporting service
 
-Assuming you have set up your account, to configure this module to use report-uri as a reporting endpoint:
+Most services have both a report-uri reporting endpoint and a report-to reporting endpoint.
 
-1. Set your Policy to "Report Only", this will produce a "Content-Security-Policy-Report-Only" header
-2. Choose Setup, then choose "Wizard" under "Policy Disposition"
-3. Copy the URL provided to the reporting URL field in the CSP module admin screen
-4. If you are using NEL, copy the Reporting API URL value to the "NEL/Reporting API reporting URL" field in the policy
-5. Save the policy in the CSP screen admin.
+In the policy screen:
 
-Once that is done, load your website and you may see some reports in the browser dev console tab. Over in the report-uri.com website, choose "CSP > Wizard" and you will see a list of directives and values that should be added to your policy.
+1. Copy the report-uri URL provided by the service to the "Endpoint for report-uri violation reports" field in the Policy editing screen
+1. Copy the "Reporting API" URL provided to the "Endpoint for Reporting API (report-to) violation reports" field in the Policy editing screen
+4. If you are using NEL, copy the Network Error Logging "Reporting API" URL value to the "NEL/Reporting API reporting URL" field in the Policy editing screen
+5. Save the policy
 
-Add and/or update the relevant directives and when happy, save your policy.
-
-### Set to Report-Only URL
-Once your policy is not reporting anything to the wizard (hint: Choose 'Clear all' in the Wizard screen), you can then switch the Reporting URL to the "Report Only" URL provided in the report-uri setup screen.
-
-This will log violations to report-uri.com which will appear in the Reporting screen and graphs.
-
-### Enforcing the policy
-When you are comfortable your website will operate correctly with the Policy in place, you can switch to using the 'Enforce' URL and turn off "Report Only" in the module admin screen for the policy.
-
+Reports will show up in your report-uri.com within a few minutes.
 
 ### Other services for reporting
 
-+ [https://github.com/seek-oss/csp-server - CSP (Content Security Policy) reports server which forwards reports to Elasticsearch.](https://github.com/seek-oss/csp-server)
-+ [ttps://docs.sentry.io/error-reporting/security-policy-reporting/ - Sentry Security Policy Reporting](https://docs.sentry.io/error-reporting/security-policy-reporting/)
++ [report-uri](https://report-uri.com)
++ [Sentry Security Policy Reporting](https://docs.sentry.io/error-reporting/security-policy-reporting/)
++ [csper](https://csper.io/about)
++ [Raygun](https://raygun.com/documentation/language-guides/browser-reporting/crash-reporting/csp/)
++ [Datadog](https://www.datadoghq.com/blog/content-security-policy-reporting-with-datadog/#csp-reporting-with-datadog)
++ [Seek OSS / CSP Server](https://github.com/seek-oss/csp-server)
 
 If you know of any other services, please make a pull request on this file or create an issue on this module.

--- a/lang/en.yml
+++ b/lang/en.yml
@@ -1,7 +1,11 @@
 en:
   ContentSecurityPolicy:
-    ALTERNATE_REPORT_URI: 'If not set, and the sending of violation reports is enabled, reports will be directed to %s and will appear in the CSP/Reports admin<br>Sending reports back to your own website may cause performance degradation.'
-    ALTERNATE_REPORT_URI_TITLE: 'Set a reporting URL that will accept violation reports'
+    ALTERNATE_REPORT_URI_DESCRIPTION: 'If not set and the sending of violation reports is enabled, reports will be directed to <code>{internal_reporting_url}</code> and will appear in the CSP/Reports screen.<br>Sending reports back to your own website may cause performance degradation.'
+    ALTERNATE_REPORT_URI_TITLE: 'Endpoint for report-uri violation reports'
+    ALTERNATE_REPORT_TO_TITLE: 'Endpoint for Reporting API (report-to) violation reports'
+    ALTERNATE_REPORT_TO_URI_DESCRIPTION: 'For services that have a separate Reporting API endpoint.<br>If not set and the sending of violation reports is enabled, reports will be directed to <code>{internal_reporting_url}</code> and will appear in the CSP/Reports screen.<br>Sending reports back to your own website may cause performance degradation.'
+    ALTERNATE_NEL_REPORT_URI_TITLE: 'NEL/Reporting API reporting URL that will accept Network Error Logging reports'
+    ALTERNATE_NEL_REPORT_URI_EXTERNAL: 'You must use an external reporting service.'
     REPORT_VIA_META_TAG: 'Reporting violations is not supported when using the meta tag delivery method'
     SEND_VIOLATION_REPORTS: "Send violation reports to a reporting system"
     SEND_VIOLATION_REPORTS_REPORT_ONLY: "'Report Only' is on -  it is wise to turn on sending violation reports"

--- a/src/Controllers/CspModelAdmin.php
+++ b/src/Controllers/CspModelAdmin.php
@@ -6,7 +6,6 @@ use SilverStripe\Admin\ModelAdmin;
 
 /**
  * Admin for managing Content Security Policy and Violation Reports
- * @author james.ellis@dpc.nsw.gov.au
  */
 class CspModelAdmin extends ModelAdmin
 {

--- a/src/Extensions/ControllerExtension.php
+++ b/src/Extensions/ControllerExtension.php
@@ -90,7 +90,7 @@ class ControllerExtension extends Extension
                 );
                 $response->addHeader(
                     "NEL",
-                    json_encode($data['nel'], JSON_UNESCAPED_SLASHES)
+                    json_encode($data['nel'])
                 );
             }
             // the relevant CSP-header with its values

--- a/src/Extensions/ControllerExtension.php
+++ b/src/Extensions/ControllerExtension.php
@@ -15,8 +15,6 @@ use SilverStripe\CMS\Model\SiteTree;
 
 /**
  * Provides an extension method so that the Controller can set the relevant CSP header
- * @author james.ellis@dpc.nsw.gov.au
- * @todo report-uri is deprecated, report-to is the new thang but browsers don't fully support report-to yet
  */
 class ControllerExtension extends Extension
 {
@@ -77,13 +75,8 @@ class ControllerExtension extends Extension
         if ($policy instanceof Policy && ($data = $policy->HeaderValues($enabled_directives))) {
             // Add the Report-To header for all
             if (!empty($data['reporting'])) {
-                /**
-                 * See: https://www.w3.org/TR/reporting/
-                 * "The header’s value is interpreted as a JSON-formatted array of objects without the outer [ and ], as described in Section 4 of [HTTP-JFV]."
-                 */
-                $encoded_report_to = json_encode($data['reporting'], JSON_UNESCAPED_SLASHES);
-                $encoded_report_to = trim($encoded_report_to, "[]");
-                $response->addHeader("Report-To", $encoded_report_to);
+                // Add Reporting-Endpoints header
+                $response->addHeader(Policy::HEADER_REPORTING_ENDPOINTS , Policy::getReportingEndpointsHeader($data['reporting']));
             }
             if (!empty($data['nel'])) {
                 $response->addHeader("NEL", json_encode($data['nel'], JSON_UNESCAPED_SLASHES));

--- a/src/Extensions/ControllerExtension.php
+++ b/src/Extensions/ControllerExtension.php
@@ -50,7 +50,7 @@ class ControllerExtension extends Extension
 
         $policy = Policy::getDefaultBasePolicy($is_live, Policy::POLICY_DELIVERY_METHOD_HEADER);
 
-        // check for Page specific policies
+        // check for Page specific policy
         if ($this->owner instanceof ContentController
             && ($data = $this->owner->data())
             && $data instanceof SiteTree) {
@@ -59,7 +59,7 @@ class ControllerExtension extends Extension
                     if (!empty($policy->ID)) {
                         /**
                          * HTTPResponse can't handle header names that are duplicated (which is allowed in the HTTP spec)
-                         * Workaround is to set the page policy for merging when HeaderValues() is called
+                         * Workaround is to set the page policy for merging when getPolicyData() is called
                          * Ref: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy#Multiple_content_security_policies
                          * Ref: https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2
                          */
@@ -72,14 +72,26 @@ class ControllerExtension extends Extension
         }
 
         // Add the policy/reporting header values
-        if ($policy instanceof Policy && ($data = $policy->HeaderValues($enabled_directives))) {
-            // Add the Report-To header for all
-            if (!empty($data['reporting'])) {
+        if ($policy instanceof Policy && ($data = $policy->getPolicyData($enabled_directives))) {
+            // Report-To header
+            // Add the Reporting-Endpoints header
+            if (!empty($data['reporting_endpoints'])) {
                 // Add Reporting-Endpoints header
-                $response->addHeader(Policy::HEADER_REPORTING_ENDPOINTS , Policy::getReportingEndpointsHeader($data['reporting']));
+                $response->addHeader(
+                    Policy::HEADER_REPORTING_ENDPOINTS,
+                    Policy::getReportingEndpointsHeader($data['reporting_endpoints'])
+                );
             }
             if (!empty($data['nel'])) {
-                $response->addHeader("NEL", json_encode($data['nel'], JSON_UNESCAPED_SLASHES));
+                // NEL is enabled
+                $response->addHeader(
+                    Policy::HEADER_REPORT_TO,
+                    Policy::getReportToHeader($data['report_to'])
+                );
+                $response->addHeader(
+                    "NEL",
+                    json_encode($data['nel'], JSON_UNESCAPED_SLASHES)
+                );
             }
             // the relevant CSP-header with its values
             $response->addHeader($data['header'], $data['policy_string']);

--- a/src/Extensions/SiteTreeExtension.php
+++ b/src/Extensions/SiteTreeExtension.php
@@ -118,7 +118,7 @@ class SiteTreeExtension extends Extension
 
         // get the default policy
         $policy = Policy::getDefaultBasePolicy($is_live, Policy::POLICY_DELIVERY_METHOD_METATAG);
-        if (!empty($policy->ID) && ($data = $policy->HeaderValues(1, Policy::POLICY_DELIVERY_METHOD_METATAG))) {
+        if (!empty($policy->ID) && ($data = $policy->getPolicyData(true))) {
             $tags[] = HTML::createTag('meta', [
                 'http-equiv' => $data['header'],
                 'content' => $data['policy_string'],
@@ -128,7 +128,7 @@ class SiteTreeExtension extends Extension
         // check for a specific page based policy
         if ($this->owner instanceof SiteTree) {
             $page_policy = Policy::getPagePolicy($this->owner, $is_live, Policy::POLICY_DELIVERY_METHOD_METATAG);
-            if (!empty($page_policy->ID) && ($data = $page_policy->HeaderValues(1, Policy::POLICY_DELIVERY_METHOD_METATAG))) {
+            if (!empty($page_policy->ID) && ($data = $page_policy->getPolicyData(true))) {
                 $tags[] = HTML::createTag('meta', [
                     'http-equiv' => $data['header'],
                     'content' => $data['policy_string'],

--- a/src/Extensions/SiteTreeExtension.php
+++ b/src/Extensions/SiteTreeExtension.php
@@ -16,7 +16,6 @@ use SilverStripe\ORM\FieldType\DBField;
 
 /**
  * Provides an extension method so that the SiteTree can gather the CSP meta tag if that is set
- * @author james.ellis@dpc.nsw.gov.au
  */
 class SiteTreeExtension extends Extension
 {

--- a/src/Models/Directive.php
+++ b/src/Models/Directive.php
@@ -13,6 +13,8 @@ use SilverStripe\Forms\DropdownField;
 use SilverStripe\Security\Permission;
 use SilverStripe\Security\PermissionProvider;
 use Symbiote\MultiValueField\Fields\KeyValueField;
+use SilverStripe\ORM\Filters\PartialMatchFilter;
+use SilverStripe\ORM\Filters\ExactMatchFilter;
 
 /**
  * A Content Security Policy directive, can be used by multiple {@link Policy}
@@ -83,6 +85,20 @@ class Directive extends DataObject implements PermissionProvider
         'UnsafeInline.Nice' =>'Unsafe Inline',
         'AllowDataUri.Nice' =>'Allow Data URI',
         'UseNonce.Nice' => 'Use Nonce'
+    ];
+
+    /**
+     * Searchable Fields
+     * @var array
+     * @config
+     */
+    private static $searchable_fields = [
+        'Key' => PartialMatchFilter::class,
+        'Enabled' => ExactMatchFilter::class,
+        'IncludeSelf' => ExactMatchFilter::class,
+        'UnsafeInline' => ExactMatchFilter::class,
+        'AllowDataUri' => ExactMatchFilter::class,
+        'UseNonce' => ExactMatchFilter::class,
     ];
 
     /**

--- a/src/Models/Directive.php
+++ b/src/Models/Directive.php
@@ -16,7 +16,6 @@ use Symbiote\MultiValueField\Fields\KeyValueField;
 
 /**
  * A Content Security Policy directive, can be used by multiple {@link Policy}
- * @author james.ellis@dpc.nsw.gov.au
  */
 class Directive extends DataObject implements PermissionProvider
 {

--- a/src/Models/Policy.php
+++ b/src/Models/Policy.php
@@ -604,7 +604,7 @@ class Policy extends DataObject implements PermissionProvider
                 $reportTo[] = $entry;
             }
             if(count($reportTo) > 0) {
-                $headerValue = json_encode( $reportTo, JSON_UNESCAPED_SLASHES );
+                $headerValue = json_encode( $reportTo );
                 /**
                  * W3C spec:
                  * The header’s value is interpreted as a JSON-formatted array of objects without the outer [ and ],

--- a/src/Models/Policy.php
+++ b/src/Models/Policy.php
@@ -47,13 +47,6 @@ class Policy extends DataObject implements PermissionProvider
     /**
      * @var bool
      * @config
-     * Support sending the "Reporting-Endpoints" header along with report-uri
-     */
-    private static $include_report_to = false;// possible issue in Chrome when the report-to directive is set, seems the report-uri directive does not work!
-
-    /**
-     * @var bool
-     * @config
      */
     private static $run_in_modeladmin = false;// whether to set the policy in ModelAdmin and descendants of ModelAdmin
 
@@ -79,13 +72,13 @@ class Policy extends DataObject implements PermissionProvider
      * @var string
      * @config
      */
-    private static $nonce_injection_method = 'requirements';// the minimum length to create 128 bit nonce value
+    private static $nonce_injection_method = 'requirements';// how a nonce is added
 
     /**
      * @var int
      * @config
      */
-    private static $max_age =  10886400;
+    private static $max_age = 3600;
 
     /**
      * Set to true to override the result of  self::checkCanApply()
@@ -94,6 +87,9 @@ class Policy extends DataObject implements PermissionProvider
      */
     private static $override_apply = false;
 
+    /**
+     * @var Policy|null
+     */
     private $merge_from_policy;// at runtime set a policy to merge other directives from, into this policy
 
     const POLICY_DELIVERY_METHOD_HEADER = 'Header';
@@ -104,7 +100,7 @@ class Policy extends DataObject implements PermissionProvider
 
     const HEADER_CSP_REPORT_ONLY = 'Content-Security-Policy-Report-Only';
     const HEADER_CSP = 'Content-Security-Policy';
-    const HEADER_REPORT_TO = 'Report-To';// see HEADER_REPORTING_ENDPOINTS
+    const HEADER_REPORT_TO = 'Report-To';
     const HEADER_REPORTING_ENDPOINTS = 'Reporting-Endpoints';
     const HEADER_NEL = 'NEL';
 
@@ -125,6 +121,7 @@ class Policy extends DataObject implements PermissionProvider
         'ReportOnly' => 'Boolean',
         'SendViolationReports' => 'Boolean',
         'AlternateReportURI' => 'Varchar(255)',// Reporting URL e.g an external service
+        'AlternateReportToURI' => 'Varchar(255)',// Reporting URL for Reporting API reports
         'EnableNEL' => 'Boolean', // Enable Network Error Logging (for supporting browsers)
         'AlternateNELReportURI' => 'Varchar(255)', // NEL reporting URL e.g an external service
         'DeliveryMethod' => 'Enum(\'Header,MetaTag\')',
@@ -203,7 +200,7 @@ class Policy extends DataObject implements PermissionProvider
 
     /**
      * Return the default base policy
-     * @param boolean $is_live
+     * @param bool $is_live
      * @param string $delivery_method
      */
     public static function getDefaultBasePolicy($is_live = false, $delivery_method = self::POLICY_DELIVERY_METHOD_HEADER)
@@ -219,7 +216,7 @@ class Policy extends DataObject implements PermissionProvider
     /**
      * Get a page specific policy based on the Page
      * @param SiteTree $page
-     * @param boolean $is_live
+     * @param bool $is_live
      * @param string $delivery_method
      */
     public static function getPagePolicy(SiteTree $page, $is_live = false, $delivery_method = self::POLICY_DELIVERY_METHOD_HEADER)
@@ -253,18 +250,6 @@ class Policy extends DataObject implements PermissionProvider
     }
 
     /**
-     * Event handler called before writing to the database.
-     */
-    public function onBeforeWrite()
-    {
-        parent::onBeforeWrite();
-        if ($this->EnableNEL == 1) {
-            // ensure on if NEL is enabled
-            $this->SendViolationReports = 1;
-        }
-    }
-
-    /**
      * Returns an array of duplicate directive Keys found
      */
     public function DuplicateDirectives()
@@ -292,7 +277,7 @@ class Policy extends DataObject implements PermissionProvider
         $fields = parent::getCMSFields();
 
 
-        // directives grid field
+        // Directives handling
         if ($this->exists()) {
             $keys = $this->DuplicateDirectives();
             if (!empty($keys)) {
@@ -306,119 +291,185 @@ class Policy extends DataObject implements PermissionProvider
             }
         }
 
-        $fields->addFieldToTab(
-            'Root.Main',
+        $fields->insertAfter(
+            'Title',
             OptionsetField::create(
                 'DeliveryMethod',
-                'Delivery Method',
-                [ self::POLICY_DELIVERY_METHOD_HEADER => 'Via an HTTP Header',  self::POLICY_DELIVERY_METHOD_METATAG => 'As a meta tag' ]
-            )->setDescription(_t('ContentSecurityPolicy.REPORT_VIA_META_TAG', 'Reporting violations is not supported when using the meta tag delivery method'))
+                _t(
+                    'ContentSecurityPolicy.DELIVERY_METHOD',
+                    'Delivery Method'
+                ),
+                [
+                    self::POLICY_DELIVERY_METHOD_HEADER => 'Via an HTTP Header',
+                    self::POLICY_DELIVERY_METHOD_METATAG => 'As a meta tag'
+                ]
+            )->setDescription(
+                _t(
+                    'ContentSecurityPolicy.REPORT_VIA_META_TAG',
+                    'Reporting violations is not supported when using the meta tag delivery method'
+                )
+            )
         );
 
-        $internal_reporting_url = ReportingEndpoint::getCurrentReportingUrl(false);
-        $fields->dataFieldByName('AlternateReportURI')
-            ->setTitle(_t('ContentSecurityPolicy.ALTERNATE_REPORT_URI_TITLE', 'Set a reporting URL that will accept violation reports'))
-            ->setDescription(sprintf(
+        // Policy options
+        $useOnPublishedSiteField = $fields->dataFieldByName('IsLive')
+            ->setTitle(
+                'Use on published website'
+            )->setDescription(
                 _t(
-                    'ContentSecurityPolicy.ALTERNATE_REPORT_URI',
-                    'If not set and the sending of violation reports is enabled,'
-                    . ' reports will be directed to %s and will appear in the CSP/Reports admin.'
-                    . ' <br>Sending reports back to your own website may cause performance degradation.'
-                ),
-                $internal_reporting_url
-            ));
-
-        $fields->dataFieldByName('AlternateNELReportURI')
-            ->setTitle(_t('ContentSecurityPolicy.ALTERNATE_NEL_REPORT_URI_TITLE', 'Set an NEL/Reporting API reporting URL that will accept Network Error Logging reports'))
-            ->setDescription(sprintf(
+                    'ContentSecurityPolicy.USE_ON_PUBLISHED_SITE',
+                    'When unchecked, this policy will be used on the draft site only'
+                )
+            );
+        $isBasePolicyField = $fields->dataFieldByName('IsBasePolicy')
+            ->setTitle('Is Base Policy')
+            ->setDescription(
                 _t(
-                    'ContentSecurityPolicy.ALTERNATE_NEL_REPORT_URI',
-                    'If not set and the sending of violation reports is enabled,'
-                            . ' NEL reports will be directed to %s and will appear in the CSP/Reports admin.'
-                            . ' <br>Sending reports back to your own website may cause performance degradation.'
-                ),
-                $internal_reporting_url
-            ));
-
-        // display policy
-        $policy = $this->HeaderValues(1, self::POLICY_DELIVERY_METHOD_HEADER, true);
-        if ($policy) {
-            $fields->addFieldsToTab(
-                'Root.Main',
-                [
-                    HeaderField::create(
-                        'EnabledDirectivePolicy',
-                        'Policy (enabled directives)'
-                    ),
-                    LiteralField::create(
-                        'PolicyEnabledDirectives',
-                        '<p><pre><code>'
-                        . $policy['header'] . ": \n"
-                        . $policy['policy_string']
-                        . '</code></pre></p>'
-                    ),
-                    LiteralField::create(
-                        'PolicyEnabledReportTo',
-                        '<p>'
-                        . (!empty($policy['reporting']) ? '<pre><code>'
-                        . self::HEADER_REPORTING_ENDPOINTS . ": " . self::getReportingEndpointsHeader($policy['reporting'])
-                        . (!empty($policy['nel']) ? "\nNEL: " . json_encode($policy['nel']) : "")
-                        . '</code></pre>' : 'No reporting set')
-                        . '</p>'
-                    )
-                ]
+                    'ContentSecurityPolicy.IS_BASE_POLICY_NOTE',
+                    'When checked, this policy will be come the base/default policy for the entire site'
+                )
             );
-        }
-
-        $policy = $this->HeaderValues(null, self::POLICY_DELIVERY_METHOD_HEADER, true);
-        if ($policy) {
-            $fields->addFieldsToTab(
-                'Root.Main',
-                [
-                    HeaderField::create(
-                        'AllDirectivePolicy',
-                        'Policy (all directives)'
-                    ),
-                    LiteralField::create(
-                        'PolicyAllDirectives',
-                        '<p><pre><code>'
-                        . $policy['header'] . ": \n"
-                        . $policy['policy_string']
-                        . '</code></pre></p>'
-                    ),
-                    LiteralField::create(
-                        'PolicyAllReportTo',
-                        '<p>'
-                        . (!empty($policy['reporting']) ? '<pre><code>'
-                        . self::HEADER_REPORTING_ENDPOINTS . ": " . self::getReportingEndpointsHeader($policy['reporting'])
-                        . (!empty($policy['nel']) ? "\nNEL: " . json_encode($policy['nel']) : "")
-                        . '</code></pre>' : 'No reporting set')
-                        . '</p>'
-                    )
-                ]
+        $minCspLevelField = $fields->dataFieldByName('MinimumCspLevel')
+            ->setTitle(
+                _t(
+                    'ContentSecurityPolicy.MINIMUM_CSP_LEVEL',
+                    'Minimum CSP Level'
+                )
+            )->setDescription(
+                _t(
+                    'ContentSecurityPolicy.MINIMUM_CSP_LEVEL_DESCRIPTION',
+                    "Setting a higher level will remove from features deprecated in previous versions, such as the 'report-uri' directive"
+                )
             );
-        }
+        $enabledField = $fields->dataFieldByName('Enabled');
 
-        $fields->dataFieldByName('SendViolationReports')->setDescription(_t('ContentSecurityPolicy.SEND_VIOLATION_REPORTS', 'Send violation reports to a reporting system'));
+        $fields->removeByName(['Enabled', 'MinimumCspLevel', 'IsBasePolicy', 'IsLive']);
+        $policyOptionsField = CompositeField::create(
+            $enabledField,
+            $minCspLevelField,
+            $useOnPublishedSiteField,
+            $isBasePolicyField
+        )->setTitle(
+            _t(
+                'ContentSecurityPolicy.POLICY_OPTIONS',
+                "Policy options"
+            )
+        );
 
-        $fields->dataFieldByName('EnableNEL')
-            ->setTitle(_t('ContentSecurityPolicy.ENABLE_NEL', 'Enable Network Error Logging (NEL)'))
-            ->setDescription(_t('ContentSecurityPolicy.ENABLE_NEL_NOTE', 'For supporting browsers. Turning this on will enable \'Send Violation Reports\''));
+        $fields->insertBefore(
+            'DeliveryMethod',
+            $policyOptionsField
+        );
 
-        $fields->dataFieldByName('ReportOnly')
-            ->setDescription(_t('ContentSecurityPolicy.REPORT_ONLY', 'Allows experimenting with the policy by monitoring (but not enforcing) its effects.'));
+        // Reporting fields
+        $sendViolationReportsField = $fields->dataFieldByName('SendViolationReports')
+            ->setDescription(
+                _t(
+                    'ContentSecurityPolicy.SEND_VIOLATION_REPORTS',
+                    'Send violation reports to a reporting system'
+                )
+            );
+
+        $reportOnlyField = $fields->dataFieldByName('ReportOnly')
+            ->setDescription(
+                _t(
+                    'ContentSecurityPolicy.REPORT_ONLY',
+                    'Allows experimenting with the policy by monitoring (but not enforcing) its effects.'
+                )
+            );
 
         if ($this->DeliveryMethod == self::POLICY_DELIVERY_METHOD_METATAG && $this->ReportOnly == 1) {
-            $fields->dataFieldByName('ReportOnly')
-            ->setRightTitle(_t('ContentSecurityPolicy.REPORT_ONLY_METATAG_WARNING', 'The delivery method is set to \'meta tag\', this setting will be ignored'));
+            $reportOnlyField->setRightTitle(
+                _t(
+                    'ContentSecurityPolicy.REPORT_ONLY_METATAG_WARNING',
+                    'The delivery method is set to \'meta tag\', this setting will be ignored'
+                )
+            );
         }
 
-        $fields->dataFieldByName('IsLive')->setTitle('Use on published website')->setDescription(_t('ContentSecurityPolicy.USE_ON_PUBLISHED_SITE', 'When unchecked, this policy will be used on the draft site only'));
-        $fields->dataFieldByName('IsBasePolicy')->setTitle('Is Base Policy')->setDescription(_t('ContentSecurityPolicy.IS_BASE_POLICY_NOTE', 'When checked, this policy will be come the base/default policy for the entire site'));
+        $internal_reporting_url = ReportingEndpoint::getCurrentReportingUrl(true);
+        $reportUriField = $fields->dataFieldByName('AlternateReportURI')
+            ->setTitle(
+                _t(
+                    'ContentSecurityPolicy.ALTERNATE_REPORT_URI_TITLE',
+                    'Endpoint for report-uri violation reports'
+                )
+            )->setDescription(
+                _t(
+                    'ContentSecurityPolicy.ALTERNATE_REPORT_URI_DESCRIPTION',
+                    'If not set and the sending of violation reports is enabled,'
+                    . ' reports will be directed to <code>{internal_reporting_url}</code> and will appear in the CSP/Reports screen.'
+                    . ' <br>Sending reports back to your own website may cause performance degradation.',
+                    [
+                        'internal_reporting_url' => htmlspecialchars($internal_reporting_url)
+                    ]
+                )
+            );
 
-        $fields->dataFieldByName('MinimumCspLevel')
-            ->setTitle(_t('ContentSecurityPolicy.MINIMUM_CSP_LEVEL', 'Minimum CSP Level'))
-            ->setDescription(_t('ContentSecurityPolicy.MINIMUM_CSP_LEVEL_DESCRIPTION', "Setting a higher level will remove from features deprecated in previous versions, such as the 'report-uri' directive"));
+        $reportToField = $fields->dataFieldByName('AlternateReportToURI')
+            ->setTitle(
+                _t(
+                    'ContentSecurityPolicy.ALTERNATE_REPORT_TO_TITLE',
+                    'Endpoint for Reporting API (report-to) violation reports'
+                )
+            )->setDescription(
+                _t(
+                    'ContentSecurityPolicy.ALTERNATE_REPORT_TO_URI_DESCRIPTION',
+                    'For services that have a separate Reporting API endpoint.<br>'
+                    . 'If not set and the sending of violation reports is enabled,'
+                    . ' reports will be directed to <code>{internal_reporting_url}</code> and will appear in the CSP/Reports screen.'
+                    . ' <br>Sending reports back to your own website may cause performance degradation.',
+                    [
+                        'internal_reporting_url' => htmlspecialchars($internal_reporting_url)
+                    ]
+                )
+            );
+        $fields->removeByName(['ReportOnly','SendViolationReports','AlternateReportURI','AlternateReportToURI']);
+        $fields->insertBefore(
+            "DeliveryMethod",
+            CompositeField::create(
+                $sendViolationReportsField,
+                $reportOnlyField,
+                $reportUriField,
+                $reportToField
+            )->setTitle(
+                _t(
+                    'ContentSecurityPolicy.CSP_REPORTING_URLS',
+                    'CSP Reporting'
+                )
+            )
+        );
+
+        // NEL fields
+        $nelReportToField = $fields->dataFieldByName('AlternateNELReportURI')
+            ->setTitle(
+                _t(
+                    'ContentSecurityPolicy.ALTERNATE_NEL_REPORT_URI_TITLE',
+                    'NEL/Reporting API reporting URL that will accept Network Error Logging reports')
+                )
+            ->setDescription(
+                _t(
+                    'ContentSecurityPolicy.ALTERNATE_NEL_REPORT_URI_EXTERNAL',
+                    'You must use an external reporting service.'
+                )
+            );
+        $enableNelField = $fields->dataFieldByName('EnableNEL')
+                ->setTitle(
+                    _t(
+                        'ContentSecurityPolicy.ENABLE_NEL',
+                        'Enable Network Error Logging (NEL)'
+                    )
+                );
+        $fields->removeByName(['AlternateNELReportURI','EnableNEL']);
+        $fields->insertBefore(
+            "DeliveryMethod",
+            CompositeField::create(
+                $nelReportToField,
+                $enableNelField
+            )->setTitle(
+                _t('ContentSecurityPolicy.NEL_REPORTING_URLS', 'NEL Reporting')
+            )
+        );
 
         // default policies aren't linked to any Pages
         if ($this->IsBasePolicy == 1) {
@@ -428,14 +479,82 @@ class Policy extends DataObject implements PermissionProvider
     }
 
     /**
+     * Tests whether the URL value passed is valid for reporting
+     * Must include scheme and host. A path is optional.
+     */
+    public static function validateUrl(string $url) : string {
+        try {
+            $parts = parse_url($url);
+            if(!isset($parts['scheme'])) {
+                throw new \Exception("Missing scheme");
+            }
+            if($parts['scheme'] != "https") {
+                throw new \Exception("Scheme is not https");
+            }
+            if(!isset($parts['host'])) {
+                throw new \Exception("Missing host");
+            }
+            return $url;
+        } catch (\Exception $e) {
+            return "";
+        }
+    }
+
+    /**
+     * Returns the max_age value from configuration
+     */
+    public function getMaxAge() : int {
+        $maxAge = self::config()->get('max_age');
+        if(!is_int($maxAge)) {
+            $maxAge = 3600;
+        }
+        return abs($maxAge);
+    }
+
+    /**
+     * Returns the include_subdomains value from configuration
+     */
+    public function getIncludeSubdomains() : bool {
+        $include = self::config()->get('include_subdomains');
+        return $include ? true : false;
+    }
+
+    /**
+     * Return the reporting URL, based on value saved or default URL
+     */
+    public function getReportingUrl() : string {
+        // Determine which reporting URI to use, external or internal
+        if ($this->AlternateReportURI) {
+            $reporting_url = $this->AlternateReportURI;
+        } else {
+            $reporting_url = ReportingEndpoint::getCurrentReportingUrl();
+        }
+        $reporting_url = self::validateUrl($reporting_url);
+        return $reporting_url;
+    }
+
+    /**
+     * Return the reporting URL for Reporting API reports, based on value saved or default URL
+     * May not be supplied.. this is used for services that have different report-uri and report-to endpoints
+     */
+    public function getReportingApiUrl() : string {
+        $url = "";
+        if ($this->AlternateReportToURI) {
+            $url = $this->AlternateReportToURI;
+        }
+        $url = self::validateUrl($url);
+        return $url;
+    }
+
+    /**
      * Given an array of reporting endpoints, return the "Reporting-Endpoints" header value
      */
-    public static function getReportingEndpointsHeader(array $reporting) : string {
-        if(count($reporting) == 0) {
+    public static function getReportingEndpointsHeader(array $reportingEndpoints) : string {
+        if(count($reportingEndpoints) == 0) {
             // No reporting endpoints provided
             return "";
         } else {
-            return implode(",", $reporting);
+            return implode(",", $reportingEndpoints);
         }
     }
 
@@ -443,7 +562,80 @@ class Policy extends DataObject implements PermissionProvider
      * Create an endpoint for the Reporting-Endpoints header
      */
     public static function getReportingEndpoint(string $endpointName, string $endpointUrl) : string {
-        return $endpointName . "=\"" . $endpointUrl . "\"";
+        if($endpointUrl = self::validateUrl($endpointUrl)) {
+            return $endpointName . "=\"" . $endpointUrl . "\"";
+        } else {
+            return "";
+        }
+    }
+
+    /**
+     * Given an array of reporting endpoints, return the "Reporting-To" header value
+     */
+    public static function getReportToHeader(array $reportToGroups) : string {
+        if(count($reportToGroups) == 0) {
+            // Nothing provided
+            return "";
+        } else {
+            $headerValue = "";
+            $reportTo = [];
+            foreach($reportToGroups as $reportToGroup) {
+                $entry = [];
+                if(!isset($reportToGroup['group']) || !is_string($reportToGroup['group'])) {
+                    continue;
+                }
+                $entry['group'] = $reportToGroup['group'];
+                if(isset($reportToGroup['max_age']) && is_int($reportToGroup['max_age'])) {
+                    $entry['max_age'] = $reportToGroup['max_age'];
+                }
+                if(isset($reportToGroup['endpoints']) && is_array($reportToGroup['endpoints'])) {
+                    $entry['endpoints'] = [];
+                    foreach($reportToGroup['endpoints'] as $endpointUrl) {
+                        if($endpointUrl = self::validateUrl($endpointUrl)) {
+                            $entry['endpoints'][] = [
+                                'url' => $endpointUrl
+                            ];
+                        }
+                    }
+                }
+                if(isset($reportToGroup['include_subdomains'])) {
+                    $entry['include_subdomains'] = $reportToGroup['include_subdomains'] ? true : false;
+                }
+                $reportTo[] = $entry;
+            }
+            if(count($reportTo) > 0) {
+                $headerValue = json_encode( $reportTo, JSON_UNESCAPED_SLASHES );
+            }
+            return $headerValue;
+        }
+    }
+
+    /**
+     * Return if NEL can be supported in this policy
+     */
+    public function isNELEnabled() : string {
+        $nelReportUrl = '';
+        if(is_string($this->AlternateNELReportURI)) {
+            $nelReportUrl = self::validateUrl( $this->AlternateNELReportURI );
+        }
+        if($this->DeliveryMethod == self::POLICY_DELIVERY_METHOD_HEADER && $this->EnableNEL == 1 && $nelReportUrl) {
+            return $nelReportUrl;
+        } else {
+            return "";
+        }
+    }
+
+    /**
+     * Checks if CSP reporting is enabled in this policy
+     * Returns the URL for reporting, if enabled
+     */
+    public function isCspReportingEnabled() : string {
+        $reporting_url = $this->getReportingUrl();
+        if($this->DeliveryMethod == self::POLICY_DELIVERY_METHOD_HEADER && $this->SendViolationReports && $reporting_url) {
+            return $reporting_url;
+        } else {
+            return "";
+        }
     }
 
     /**
@@ -458,15 +650,15 @@ class Policy extends DataObject implements PermissionProvider
 
     /**
      * Retrieve the policy in a format for use in the Header or Meta Tag handling
-     * @param int|null $enabled filter by Enabled directives only
+     * @param mixed $enabled filter by Enabled directives only
      * @param bool $pretty format each policy line on a new line
      * @return string
      */
-    public function getPolicy($enabled = 1, $pretty = false)
+    public function getPolicy($enabled = true, $pretty = false) : string
     {
         $directives = $this->Directives()->sort("ID ASC");
         if (!is_null($enabled)) {
-            $directives = $directives->filter('Enabled', (bool)$enabled);
+            $directives = $directives->filter(['Enabled' => $enabled ]);
         }
         $policy = "";
 
@@ -474,7 +666,7 @@ class Policy extends DataObject implements PermissionProvider
         if ($this->merge_from_policy instanceof Policy) {
             $merge_from_policy_directives = $this->merge_from_policy->Directives()->sort("ID ASC");
             if (!is_null($enabled)) {
-                $merge_from_policy_directives = $merge_from_policy_directives->filter('Enabled', (bool)$enabled);
+                $merge_from_policy_directives = $merge_from_policy_directives->filter(['Enabled' => $enabled ]);
             }
         }
 
@@ -530,101 +722,112 @@ class Policy extends DataObject implements PermissionProvider
 
     /**
      * Header values
-     * @returns array
-     * @param int|null $enabled
+     * @deprecated
+     * @param bool|null $enabled
      * @param string $method
      * @param bool $pretty
      */
     public function HeaderValues($enabled = 1, $method = self::POLICY_DELIVERY_METHOD_HEADER, $pretty = false)
     {
+        if(!is_null($enabled)) {
+            $enabled = $enabled == 1;
+        }
+        return $this->getPolicyData($enabled);
+    }
+
+    /**
+     * Header values
+     * @param bool|null $enabled
+     * @param bool $pretty
+     */
+    public function getPolicyData(?bool $enabled, bool $pretty = false ) : ?array {
         $policy_string = trim($this->getPolicy($enabled, $pretty));
         if (!$policy_string) {
-            return false;
+            return null;
         }
-        $reporting = $nel = [];
+        $report_to = $reporting_endpoints = $nel = [];
         $header = self::HEADER_CSP;
         if ($this->ReportOnly == 1) {
-            if ($method == self::POLICY_DELIVERY_METHOD_METATAG) {
+            if ($this->DeliveryMethod == self::POLICY_DELIVERY_METHOD_METATAG) {
                 // MetaTag delivery does not support CSPRO, go no further (delivers NO CSP headers)
-                return false;
-            } elseif ($method == self::POLICY_DELIVERY_METHOD_HEADER) {
+                return null;
+            } elseif ($this->DeliveryMethod == self::POLICY_DELIVERY_METHOD_HEADER) {
                 // only HTTP Header can use CSPRO currently
                 $header = self::HEADER_CSP_REPORT_ONLY;
             }
         }
 
-        if ($method == self::POLICY_DELIVERY_METHOD_HEADER && $this->SendViolationReports) {
-            $include_report_to = $this->config()->get('include_report_to');
+        /**
+         * The REQUIRED max-age member defines the endpoint group’s lifetime, as a non-negative integer number of seconds
+         * https://wicg.github.io/reporting/#max-age-member
+         */
+        $max_age = $this->getMaxAge();
+        $include_subdomains = $this->getIncludeSubdomains();
 
-            // Determine which reporting URI to use, external or internal
-            if ($this->AlternateReportURI) {
-                $reporting_url = $this->AlternateReportURI;
-            } else {
-                $reporting_url = ReportingEndpoint::getCurrentReportingUrl();
-            }
+        // Get Reporting URL for CSP
+        if ($reporting_url = $this->isCspReportingEnabled()) {
 
             /**
              * Reporting changed between CSP Level 2 and 3
-             * With a min. level of 2, we send report-uri and Report-To headers
-             * With a min. level of 3, we send Reporting-Endpoints only
+             * With a min. level < 3, we send report-uri and report-to directives
+             * With a min. level of 3, we send report-to with accompanying headers
              * @see https://wicg.github.io/reporting/#examples
              * @see https://w3c.github.io/webappsec-csp/#directives-reporting
              * @note the Abort steps here - https://w3c.github.io/reporting/#process-header
-             * If you are testing locally with a self signed cert or without a cert, it's possible Report-To will make no difference in supporting Browsers e.g Chrome 70+
+             * If you are testing locally with a self signed cert or without a cert, it's possible Report-To / Reporting-Endpoints will make no difference in supporting Browsers e.g Chrome 70+
              */
 
-            $report_to = "";
-            $min_csp_level = $this->MinimumCspLevel;
-
-            /**
-             * The REQUIRED max-age member defines the endpoint group’s lifetime, as a non-negative integer number of seconds
-             * https://wicg.github.io/reporting/#max-age-member
-             */
-            $max_age = abs($this->config()->get('max_age'));
-
-            $include_subdomains = (bool)$this->config()->get('include_subdomains');
+            $report_to_directive = $report_uri_directive = "";
 
             $reporting_group = self::DEFAULT_REPORTING_GROUP;
 
-            if ($min_csp_level < 3) {
+            if ($this->MinimumCspLevel < 3) {
                 // Only 1,2 will add a report-uri, when selecting '3' this is ignored
-                $report_to .= "report-uri {$reporting_url};";
+                $report_uri_directive = "report-uri {$reporting_url};";
             }
 
-            if ($include_report_to) {
-                // Add Reporting-Endpoints header (previously Report-To)
-                // Browsers not supporting this will use report-uri
-                $report_to .= "report-to {$reporting_group};";
-                $reporting[ self::DEFAULT_REPORTING_GROUP ] = self::getReportingEndpoint(self::DEFAULT_REPORTING_GROUP, $reporting_url);
+            // report-to directive for CSP
+            $report_to_directive = "report-to {$reporting_group};";
+            // The report-to endpoint url can be different from the report-uri URL, in some services
+            $reportingapi_url = $this->getReportingApiUrl();
+            if(!$reportingapi_url) {
+                $reportingapi_url = $reporting_url;
+            }
+            // Reporting-Endpoints for CSP
+            $reporting_endpoints[ self::DEFAULT_REPORTING_GROUP ] = self::getReportingEndpoint(self::DEFAULT_REPORTING_GROUP, $reportingapi_url);
+
+            if($report_uri_directive || $report_to_directive) {
+                $policy_string .= $report_uri_directive . $report_to_directive;
             }
 
-            // only apply report_to if there is a URL and the
-            $policy_string .= $report_to;
+        }
 
-            // Network Error Logging support
-            if ($this->EnableNEL == 1) {
-                if ($this->AlternateNELReportURI) {
-                    $nel_reporting_url = $this->AlternateNELReportURI;
-                } else {
-                    $nel_reporting_url = ReportingEndpoint::getCurrentReportingUrl();// sent report to self
-                }
-
-                $nel = [
-                    "report_to" => self::DEFAULT_REPORTING_GROUP_NEL,
-                    "max_age" => $max_age,
-                    "include_subdomains" => $include_subdomains
-                ];
-
-                // Reporting-Endpoints endpoint for NEL
-                $reporting[ self::DEFAULT_REPORTING_GROUP_NEL ] = self::getReportingEndpoint(self::DEFAULT_REPORTING_GROUP_NEL, $nel_reporting_url);
-            }
+        // Network Error Logging support
+        if ($nelReportUrl = $this->isNELEnabled()) {
+            // NEL header values
+            $nel = [
+                "report_to" => self::DEFAULT_REPORTING_GROUP_NEL,
+                "max_age" => $max_age,
+                "include_subdomains" => $include_subdomains
+            ];
+            // NEL requires Report-To header
+            $report_to[ self::DEFAULT_REPORTING_GROUP_NEL ] = [
+                "group" => self::DEFAULT_REPORTING_GROUP_NEL,
+                "max_age" => $max_age,
+                "include_subdomains" => $include_subdomains,
+                "endpoints" => [
+                    $nelReportUrl
+                ]
+            ];
         }
 
         $response = [
-            'header' => $header,
-            'policy_string' => $policy_string,
-            'reporting' => $reporting,
-            'nel' => $nel
+            'header' => $header, // the CSP header
+            'policy_string' => trim($policy_string), // the CSP policy
+            'reporting' => [],// See report entries below
+            'report_to' => $report_to, // Report-To data
+            'reporting_endpoints' => $reporting_endpoints, // Reporting-Endpoints data
+            'nel' => $nel // NEL support
         ];
 
         return $response;
@@ -632,10 +835,10 @@ class Policy extends DataObject implements PermissionProvider
 
     /**
      * Given a policy string, parse out the parts into key value pairs
-     * @returns array
+     * @return array
      * @param string $policy_string the value of a Content-Security-Policy[-Report-Only] header
      */
-    public static function parsePolicy($policy_string)
+    public static function parsePolicy($policy_string) : array
     {
         $parts = explode(";", rtrim($policy_string, ";"));
         $data = [];
@@ -646,7 +849,10 @@ class Policy extends DataObject implements PermissionProvider
         return $data;
     }
 
-    public static function getNonceEnabledDirectives($policy_string) {
+    /**
+     * Get directives that have a nonce-* value
+     */
+    public static function getNonceEnabledDirectives($policy_string) : array {
         $directives = [];
         $parts = self::parsePolicy($policy_string);
         foreach($parts as $k=>$v) {
@@ -707,6 +913,37 @@ class Policy extends DataObject implements PermissionProvider
         }
 
         return false;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function validate()
+    {
+        $result = parent::validate();
+        if ($this->AlternateReportURI) {
+            $valid = self::validateUrl( $this->AlternateReportURI );
+            if(!$valid) {
+                $result->addError(
+                    _t(
+                        'ContentSecurityPolicy.INVALID_URL',
+                        'The reporting URL is not valid'
+                    )
+                );
+            }
+        }
+        if ($this->AlternateNELReportURI) {
+            $valid = self::validateUrl( $this->AlternateNELReportURI );
+            if(!$valid) {
+                $result->addError(
+                    _t(
+                        'ContentSecurityPolicy.INVALID_URL_NEL',
+                        'The NEL reporting URL is not valid'
+                    )
+                );
+            }
+        }
+        return $result;
     }
 
     public function canView($member = null)

--- a/src/Models/Policy.php
+++ b/src/Models/Policy.php
@@ -605,6 +605,12 @@ class Policy extends DataObject implements PermissionProvider
             }
             if(count($reportTo) > 0) {
                 $headerValue = json_encode( $reportTo, JSON_UNESCAPED_SLASHES );
+                /**
+                 * W3C spec:
+                 * The header’s value is interpreted as a JSON-formatted array of objects without the outer [ and ],
+                 * as described in Section 4 of [HTTP-JFV].
+                 */
+                $headerValue = trim($headerValue, "[]");
             }
             return $headerValue;
         }

--- a/src/Models/ViolationReport.php
+++ b/src/Models/ViolationReport.php
@@ -11,10 +11,21 @@ use SilverStripe\Security\PermissionProvider;
 /**
  * CSP Violation Report
  * @note refer to https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP#Sample_violation_report
- * @author james.ellis@dpc.nsw.gov.au
  */
 class ViolationReport extends DataObject implements PermissionProvider
 {
+
+    /**
+     * @var string
+     * Report type created by report-uri requests
+     */
+    const REPORT_TYPE_CSP_REPORT = "csp-report";
+
+    /**
+     * @var string
+     * Report type created by Reporting-Endpoint requests
+     */
+    const REPORT_TYPE_CSP_VIOLATION = "csp-violation";
 
     /**
      * @var string
@@ -89,9 +100,26 @@ class ViolationReport extends DataObject implements PermissionProvider
     /**
      * Create a new Violation Report per data spec
      */
-    public static function create_report($data, $user_agent)
+    public static function create_report(array $data, string $contentType) : ?ViolationReport
     {
-        $report = new ViolationReport();
+        if(isset($data[ self::REPORT_TYPE_CSP_REPORT ]) && $contentType == "application/csp-report") {
+            // report-uri report (application/csp-report)
+            return self::create_csp_report($data[ self::REPORT_TYPE_CSP_REPORT ]);
+        } else if($contentType == "application/reports+json") {
+            // Reporting-Endpoints report (multiple reports - application/reports+json)
+            return self::create_csp_violation($data);
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * Create a new Violation Report for report-uri spec submitted reports
+     * Ref: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/report-uri
+     */
+    protected static function create_csp_report(array $data) : ?ViolationReport {
+        $user_agent = isset($_SERVER['HTTP_USER_AGENT']) ? $_SERVER['HTTP_USER_AGENT'] : '';
+        $report = ViolationReport::create();
         $report->DocumentUri = isset($data['document-uri']) ? $data['document-uri'] : '';
         $report->Referrer = isset($data['referrer']) ? $data['referrer'] : '';
         $report->BlockedUri = isset($data['blocked-uri']) ? $data['blocked-uri'] : '';
@@ -103,6 +131,40 @@ class ViolationReport extends DataObject implements PermissionProvider
         $report->SourceFile =  isset($data['source-file']) ? $data['source-file'] : '';
         $report->UserAgent = $user_agent;
         $report->write();
+        return $report;
+    }
+
+    /**
+     * Handle Reporting API reports, for csp-violation reports
+     * Ref: https://w3c.github.io/reporting/
+     */
+    protected static function create_csp_violation(array $reports) : ?ViolationReport {
+        if(count($reports) == 0) {
+            return null;
+        }
+        $report = null;
+        $user_agent = isset($_SERVER['HTTP_USER_AGENT']) ? $_SERVER['HTTP_USER_AGENT'] : '';
+        foreach($reports as $reportBody) {
+            if(empty($reportBody['body'])) {
+                continue;
+            }
+            if( isset($reportBody['type']) && $reportBody['type'] == self::REPORT_TYPE_CSP_VIOLATION ) {
+                $data = $reportBody['body'];
+                $report = ViolationReport::create();
+                $report->DocumentUri = isset($data['documentURL']) ? $data['documentURL'] : '';
+                $report->Referrer = isset($data['referrer']) ? $data['referrer'] : '';
+                $report->BlockedUri = isset($data['blockedURL']) ? $data['blockedURL'] : '';
+                $report->ViolatedDirective = isset($data['effectiveDirective']) ? $data['effectiveDirective'] : '';
+                $report->OriginalPolicy = isset($data['originalPolicy']) ? $data['originalPolicy'] : '';
+                $report->LineNumber =  isset($data['lineNumber']) ? $data['lineNumber'] : '';
+                $report->ColumnNumber =  isset($data['columnNumber']) ? $data['columnNumber'] : '';
+                $report->Disposition =  isset($data['disposition']) ? $data['disposition'] : '';
+                $report->SourceFile =  isset($data['sourceFile']) ? $data['sourceFile'] : '';
+                $report->UserAgent = $user_agent;
+                $report->write();
+            }
+        }
+        // return the last report created
         return $report;
     }
 

--- a/src/Services/Logger.php
+++ b/src/Services/Logger.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace NSWDPC\Utilities\ContentSecurityPolicy;
+
+use Psr\Log\LoggerInterface;
+use SilverStripe\Core\Injector\Injector;
+use SilverStripe\Security\Security;
+
+/**
+ * Simple log handling
+ */
+class Logger
+{
+    public static function log($message, $level = "DEBUG")
+    {
+        Injector::inst()->get(LoggerInterface::class)->log($level, $message);
+    }
+}

--- a/tests/AbstractPolicyFunctionalTest.php
+++ b/tests/AbstractPolicyFunctionalTest.php
@@ -214,8 +214,8 @@ abstract class AbstractPolicyFunctionalTest extends FunctionalTest
         $header_nel = $result->getHeader(Policy::HEADER_NEL);
         $this->assertNotNull($header_nel, "No " . Policy::HEADER_NEL . " Header!");
 
-        $header_report_to = $result->getHeader(Policy::HEADER_REPORT_TO);
-        $this->assertNotNull($header_report_to, "No " . Policy::HEADER_REPORT_TO . " Header!");
+        $header_report_to = $result->getHeader(Policy::HEADER_REPORTING_ENDPOINTS);
+        $this->assertNotNull($header_report_to, "No " . Policy::HEADER_REPORTING_ENDPOINTS . " Header!");
 
         $policy->ReportOnly = 1;
         $policy->write();
@@ -227,7 +227,7 @@ abstract class AbstractPolicyFunctionalTest extends FunctionalTest
         $header_csp_report_only = $result->getHeader(Policy::HEADER_CSP_REPORT_ONLY);
         $this->assertNotNull($header_csp_report_only, "No " . Policy::HEADER_CSP_REPORT_ONLY . " Header!");
 
-        // Turn off Report-To and NEL
+        // Turn off Reporting and NEL
         $policy->SendViolationReports = 0;
         $policy->EnableNEL = 0;
         $policy->write();
@@ -344,8 +344,8 @@ abstract class AbstractPolicyFunctionalTest extends FunctionalTest
         $header_nel = $result->getHeader(Policy::HEADER_NEL);
         $this->assertNotNull($header_nel, "No " . Policy::HEADER_NEL . " Header!");
 
-        $header_report_to = $result->getHeader(Policy::HEADER_REPORT_TO);
-        $this->assertNotNull($header_report_to, "No " . Policy::HEADER_REPORT_TO . " Header!");
+        $header_report_to = $result->getHeader(Policy::HEADER_REPORTING_ENDPOINTS);
+        $this->assertNotNull($header_report_to, "No " . Policy::HEADER_REPORTING_ENDPOINTS . " Header!");
     }
 
     /**

--- a/tests/AbstractPolicyFunctionalTest.php
+++ b/tests/AbstractPolicyFunctionalTest.php
@@ -13,6 +13,7 @@ use SilverStripe\Versioned\Versioned;
 use SilverStripe\Control\HTTPResponse;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\View\Requirements;
+use SilverStripe\Control\Director;
 use Exception;
 
 abstract class AbstractPolicyFunctionalTest extends FunctionalTest
@@ -22,7 +23,7 @@ abstract class AbstractPolicyFunctionalTest extends FunctionalTest
 
     protected static $disable_themes = true;
 
-    // protected $usesDatabase = true;
+    protected $usesDatabase = true;
 
     protected static $fixture_file = 'PolicyFunctionalTest.yml';
 
@@ -38,13 +39,19 @@ abstract class AbstractPolicyFunctionalTest extends FunctionalTest
 
     abstract protected function getInjectionMethod();
 
-    public function setUp() : void
+    protected function setUp() : void
     {
         Config::modify()->set( Policy::class, 'nonce_injection_method', $this->getInjectionMethod());
         parent::setUp();
+        // Ensure protocol is https, to ensure reporting URL is validated
+        Config::modify()->set(
+            Director::class,
+            'alternate_base_url',
+            'https://localhost/'
+        );
     }
 
-    public function tearDown() : void
+    protected function tearDown() : void
     {
         parent::tearDown();
     }
@@ -136,8 +143,8 @@ abstract class AbstractPolicyFunctionalTest extends FunctionalTest
             'IsBasePolicy' => 1,
             'ReportOnly' => 0,
             'SendViolationReports' => 1,
-            'EnableNEL' => 1,
-            'AlternateReportURI' => '',
+            'EnableNEL' => 0,
+            'AlternateReportURI' => 'https://reporting.example.com/csp/report',
             'DeliveryMethod' => Policy::POLICY_DELIVERY_METHOD_HEADER,
             'MinimumCspLevel' => 1,
         ]);
@@ -209,13 +216,22 @@ abstract class AbstractPolicyFunctionalTest extends FunctionalTest
         $this->assertTrue($result instanceof HTTPResponse);
 
         $header_csp = $result->getHeader(Policy::HEADER_CSP);
-        $this->assertNotNull($header_csp, "No " . Policy::HEADER_CSP . " Header!");
+        $this->assertNotNull($header_csp, "No " . Policy::HEADER_CSP . " header");
 
         $header_nel = $result->getHeader(Policy::HEADER_NEL);
-        $this->assertNotNull($header_nel, "No " . Policy::HEADER_NEL . " Header!");
+        $header_report_to = $result->getHeader(Policy::HEADER_REPORT_TO);
+        $this->assertNull($header_nel, Policy::HEADER_NEL . " header found");
+        $this->assertNull($header_nel, Policy::HEADER_REPORT_TO . " header found");
 
-        $header_report_to = $result->getHeader(Policy::HEADER_REPORTING_ENDPOINTS);
-        $this->assertNotNull($header_report_to, "No " . Policy::HEADER_REPORTING_ENDPOINTS . " Header!");
+        $header_reporting_endpoints = $result->getHeader(Policy::HEADER_REPORTING_ENDPOINTS);
+        $this->assertNotNull($header_reporting_endpoints, "No " . Policy::HEADER_REPORTING_ENDPOINTS . " header");
+        $this->assertStringContainsString(
+            Policy::getReportingEndpoint(
+                Policy::DEFAULT_REPORTING_GROUP,
+                $policy->getReportingUrl()
+            ),
+            $header_reporting_endpoints
+        );
 
         $policy->ReportOnly = 1;
         $policy->write();
@@ -225,25 +241,39 @@ abstract class AbstractPolicyFunctionalTest extends FunctionalTest
         $this->assertTrue($result instanceof HTTPResponse);
 
         $header_csp_report_only = $result->getHeader(Policy::HEADER_CSP_REPORT_ONLY);
-        $this->assertNotNull($header_csp_report_only, "No " . Policy::HEADER_CSP_REPORT_ONLY . " Header!");
+        $this->assertNotNull($header_csp_report_only, "No " . Policy::HEADER_CSP_REPORT_ONLY . " header");
 
-        // Turn off Reporting and NEL
+        $header_reporting_endpoints = $result->getHeader(Policy::HEADER_REPORTING_ENDPOINTS);
+        $this->assertNotNull($header_reporting_endpoints, "No " . Policy::HEADER_REPORTING_ENDPOINTS . " header");
+        $this->assertStringContainsString(
+            Policy::getReportingEndpoint(
+                Policy::DEFAULT_REPORTING_GROUP,
+                $policy->getReportingUrl()
+            ),
+            $header_reporting_endpoints
+        );
+
+        // Turn off Reporting
         $policy->SendViolationReports = 0;
-        $policy->EnableNEL = 0;
         $policy->write();
 
         $result = $this->get('home/');
 
         $this->assertTrue($result instanceof HTTPResponse);
 
+        // Report only header should be present
         $header_csp_report_only = $result->getHeader(Policy::HEADER_CSP_REPORT_ONLY);
-        $this->assertNotNull($header_csp_report_only, "No " . Policy::HEADER_CSP_REPORT_ONLY . " Header!");
+        $this->assertNotNull($header_csp_report_only, "No " . Policy::HEADER_CSP_REPORT_ONLY . " header");
 
+        // Reporting-Endpoints should not be present
+        $header_reporting_endpoints = $result->getHeader(Policy::HEADER_REPORTING_ENDPOINTS);
+        $this->assertNull($header_reporting_endpoints, Policy::HEADER_REPORTING_ENDPOINTS . " header found");
+
+        // NEL should remain off
         $header_nel = $result->getHeader(Policy::HEADER_NEL);
-        $this->assertNull($header_nel, Policy::HEADER_NEL . " Header!");
-
         $header_report_to = $result->getHeader(Policy::HEADER_REPORT_TO);
-        $this->assertNull($header_report_to, Policy::HEADER_REPORT_TO . " Header!");
+        $this->assertNull($header_nel, Policy::HEADER_NEL . " header found");
+        $this->assertNull($header_nel, Policy::HEADER_REPORT_TO . " header found");
     }
 
     /**
@@ -261,7 +291,7 @@ abstract class AbstractPolicyFunctionalTest extends FunctionalTest
             'IsBasePolicy' => 1,
             'ReportOnly' => 0,
             'SendViolationReports' => 1,
-            'EnableNEL' => 1,
+            'EnableNEL' => 0,
             'AlternateReportURI' => '',
             'DeliveryMethod' => Policy::POLICY_DELIVERY_METHOD_HEADER,
             'MinimumCspLevel' => 1,
@@ -340,12 +370,11 @@ abstract class AbstractPolicyFunctionalTest extends FunctionalTest
             && strpos($formatted_values['font-src'], "https://pagetestfont.example.com") !== false
         );
 
-        // the main base policy sets these
         $header_nel = $result->getHeader(Policy::HEADER_NEL);
-        $this->assertNotNull($header_nel, "No " . Policy::HEADER_NEL . " Header!");
+        $this->assertNull($header_nel, Policy::HEADER_NEL . " Header!");
 
-        $header_report_to = $result->getHeader(Policy::HEADER_REPORTING_ENDPOINTS);
-        $this->assertNotNull($header_report_to, "No " . Policy::HEADER_REPORTING_ENDPOINTS . " Header!");
+        $header_reporting_endpoints = $result->getHeader(Policy::HEADER_REPORTING_ENDPOINTS);
+        $this->assertNotNull($header_reporting_endpoints, "No " . Policy::HEADER_REPORTING_ENDPOINTS . " Header!");
     }
 
     /**
@@ -439,6 +468,7 @@ abstract class AbstractPolicyFunctionalTest extends FunctionalTest
                 switch ($equiv) {
                     case Policy::HEADER_CSP_REPORT_ONLY:
                     case Policy::HEADER_REPORT_TO:
+                    case Policy::HEADER_REPORTING_ENDPOINTS:
                     case Policy::HEADER_NEL:
                         // none of these headers are allowed
                         throw new Exception("Header {$equiv} found");
@@ -588,6 +618,7 @@ abstract class AbstractPolicyFunctionalTest extends FunctionalTest
                 switch ($equiv) {
                         case Policy::HEADER_CSP_REPORT_ONLY:
                         case Policy::HEADER_REPORT_TO:
+                        case Policy::HEADER_REPORTING_ENDPOINTS:
                         case Policy::HEADER_NEL:
                             // causes the test to fail
                             throw new Exception("Header {$equiv} found");

--- a/tests/NonceTest.php
+++ b/tests/NonceTest.php
@@ -10,7 +10,7 @@ use SilverStripe\Dev\SapphireTest;
 
 class NonceTest extends SapphireTest {
 
-    public function setUp() : void {
+    protected function setUp() : void {
         parent::setUp();
         // clear nonce for each test
         Nonce::clear();

--- a/tests/PolicyFunctionalTest.php
+++ b/tests/PolicyFunctionalTest.php
@@ -7,7 +7,7 @@ use NSWDPC\Utilities\ContentSecurityPolicy\Policy;
 require_once(dirname(__FILE__) . '/AbstractPolicyFunctionalTest.php');
 
 /**
- * Functional test using Requirements)_Backend as the nonce injection solution
+ * Functional test using Requirements_Backend as the nonce injection solution
  */
 class PolicyFunctionalTest extends AbstractPolicyFunctionalTest
 {

--- a/tests/PolicyTest.php
+++ b/tests/PolicyTest.php
@@ -114,9 +114,15 @@ class PolicyTest extends SapphireTest
         $this->assertTrue(strpos($header['policy_string'], "'self'") !== false);
         $this->assertTrue(strpos($header['policy_string'], "font-src") === 0);
         $this->assertTrue(strpos($header['policy_string'], "https://example.com https://www.example.net https://*.example.org") !== false);
-        $this->assertEquals($header['reporting'][0]['endpoints'][0]['url'], ReportingEndpoint::getCurrentReportingUrl(true));
+        $this->assertEquals(
+            $header['reporting'][ Policy::DEFAULT_REPORTING_GROUP ],
+            Policy::getReportingEndpoint(Policy::DEFAULT_REPORTING_GROUP, ReportingEndpoint::getCurrentReportingUrl(true))
+        );
         $this->assertEquals($header['nel']['report_to'], Policy::DEFAULT_REPORTING_GROUP_NEL);
-        $this->assertEquals($header['reporting'][0]['group'], Policy::DEFAULT_REPORTING_GROUP);// TODO handle based on group name ?
+        $this->assertEquals(
+            $header['reporting'][ Policy::DEFAULT_REPORTING_GROUP_NEL ],
+            Policy::getReportingEndpoint(Policy::DEFAULT_REPORTING_GROUP_NEL, ReportingEndpoint::getCurrentReportingUrl(true))
+        );
 
         $policy->EnableNEL = 0;
         $policy->write();

--- a/tests/PolicyTest.php
+++ b/tests/PolicyTest.php
@@ -8,25 +8,27 @@ use NSWDPC\Utilities\ContentSecurityPolicy\ReportingEndpoint;
 use NSWDPC\Utilities\ContentSecurityPolicy\Policy;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\Core\Config\Config;
+use SilverStripe\Control\Director;
 
 class PolicyTest extends SapphireTest
 {
 
     protected $usesDatabase = true;
 
-    private $include_report_to = false;
-
-    public function setUp() : void
+    protected function setUp() : void
     {
         parent::setUp();
-        $this->include_report_to = Config::inst()->get(Policy::class, 'include_report_to');
-        Config::modify()->set(Policy::class, 'include_report_to', true);
+        // Ensure protocol is https, to ensure reporting URL is validated
+        Config::modify()->set(
+            Director::class,
+            'alternate_base_url',
+            'https://localhost/'
+        );
     }
 
-    public function tearDown() : void
+    protected function tearDown() : void
     {
         parent::tearDown();
-        Config::modify()->set(Policy::class, 'include_report_to', $this->include_report_to);
     }
 
     private function createPolicy($data)
@@ -67,25 +69,11 @@ class PolicyTest extends SapphireTest
             'IsBasePolicy' => 1,
             'ReportOnly' => 0,
             'SendViolationReports' => 1,
-            'EnableNEL' => 1,
-            'AlternateReportURI' => '',
+            'EnableNEL' => 1, // NEL not enabled as not NEL reporting URL
+            'AlternateReportURI' => 'https://localhost/csp/reporting',
             'DeliveryMethod' => Policy::POLICY_DELIVERY_METHOD_HEADER,
             'MinimumCspLevel' => 1,
         ]);
-
-        $non_enabled_policy = $this->createPolicy([
-            'Title' => 'Test Policy',
-            'Enabled' => 0,
-            'IsLive' => 0,
-            'IsBasePolicy' => 0,
-            'ReportOnly' => 0,
-            'SendViolationReports' => 1,
-            'EnableNEL' => 1,
-            'AlternateReportURI' => '',
-            'DeliveryMethod' => Policy::POLICY_DELIVERY_METHOD_HEADER,
-            'MinimumCspLevel' => 1,
-        ]);
-        $non_enabled_policy->write();
 
         $base_policy = Policy::getDefaultBasePolicy();
 
@@ -105,67 +93,153 @@ class PolicyTest extends SapphireTest
 
         $this->assertEquals($policy->Directives()->count(), 1);
 
-        $header = $policy->HeaderValues(1, Policy::POLICY_DELIVERY_METHOD_HEADER);
+        $header = $policy->getPolicyData(true);
 
-        $this->assertTrue(isset($header['header']) && isset($header['policy_string']) && isset($header['reporting']) && isset($header['nel']));
+        $this->assertTrue(isset($header['header']));
+        $this->assertTrue(isset($header['policy_string']));
+        $this->assertTrue(isset($header['reporting_endpoints']));
+        $this->assertEmpty($header['report_to']);
+        $this->assertEmpty($header['nel']);
 
         $this->assertEquals($header['header'], Policy::HEADER_CSP);
         $this->assertTrue(strpos($header['policy_string'], 'data:') !== false);
         $this->assertTrue(strpos($header['policy_string'], "'self'") !== false);
         $this->assertTrue(strpos($header['policy_string'], "font-src") === 0);
         $this->assertTrue(strpos($header['policy_string'], "https://example.com https://www.example.net https://*.example.org") !== false);
+
+        $this->assertArrayHasKey(Policy::DEFAULT_REPORTING_GROUP, $header['reporting_endpoints']);
         $this->assertEquals(
-            $header['reporting'][ Policy::DEFAULT_REPORTING_GROUP ],
-            Policy::getReportingEndpoint(Policy::DEFAULT_REPORTING_GROUP, ReportingEndpoint::getCurrentReportingUrl(true))
-        );
-        $this->assertEquals($header['nel']['report_to'], Policy::DEFAULT_REPORTING_GROUP_NEL);
-        $this->assertEquals(
-            $header['reporting'][ Policy::DEFAULT_REPORTING_GROUP_NEL ],
-            Policy::getReportingEndpoint(Policy::DEFAULT_REPORTING_GROUP_NEL, ReportingEndpoint::getCurrentReportingUrl(true))
+            $header['reporting_endpoints'][ Policy::DEFAULT_REPORTING_GROUP ],
+            Policy::getReportingEndpoint(
+                Policy::DEFAULT_REPORTING_GROUP,
+                $policy->getReportingUrl()
+            )
         );
 
-        $policy->EnableNEL = 0;
-        $policy->write();
+        // NEL not enabled as no NEL reporting URL in policy
+        $this->assertEmpty( $policy->isNELEnabled() );
 
-        $header = $policy->HeaderValues(1, Policy::POLICY_DELIVERY_METHOD_HEADER);
-        $this->assertTrue(empty($header['nel']));
-
+        // Turn off violation report sending
         $policy->SendViolationReports = 0;
         $policy->write();
-        $header = $policy->HeaderValues(1, Policy::POLICY_DELIVERY_METHOD_HEADER);
+        $this->assertEmpty( $policy->isCspReportingEnabled() );
 
-        $this->assertTrue(empty($header['reporting']));
+        // Policy should have no endpoints
+        $header = $policy->getPolicyData(true);
+        $this->assertTrue(empty($header['reporting_endpoints']));
 
         $policy->ReportOnly = 1;
         $policy->write();
 
-        $header = $policy->HeaderValues(1, Policy::POLICY_DELIVERY_METHOD_HEADER);
+        // Violation reporting is still off
+        $this->assertEmpty( $policy->isCspReportingEnabled() );
 
+        // Header should have changed
+        $header = $policy->getPolicyData(true);
         $this->assertTrue(isset($header['header']) && Policy::HEADER_CSP_REPORT_ONLY);
 
+        // Make policy non-enabled
         $policy->Enabled = 0;
         $policy->IsBasePolicy = 0;
         $policy->write();
 
         // There should be no base policy now
         $not_base_policy = Policy::getDefaultBasePolicy();
-
         $this->assertNull($not_base_policy);
 
-        // play switcheroo with the Base Policy
-        $policy->IsBasePolicy = 1;
-        $policy->write();
 
-        $non_enabled_policy->IsBasePolicy = 1;
-        $non_enabled_policy->write();
+    }
 
-        $check_policy = Policy::get()->byId($policy->ID);
+    public function testReportingURLs() {
+        $this->clearAllPolicies();
 
-        $this->assertTrue($check_policy && $check_policy->IsBasePolicy == 0, 'Previous Base policy was not valid');
+        $policy = $this->createPolicy([
+            'Title' => 'Test Policy with 2 reporting URLs',
+            'Enabled' => 1,
+            'IsLive' => 1,
+            'IsBasePolicy' => 1,
+            'ReportOnly' => 0,
+            'SendViolationReports' => 1,
+            'EnableNEL' => 0, // NEL not enabled as not NEL reporting URL
+            'AlternateReportURI' => 'https://example.net/csp/report-uri',// for report-uri reports
+            'AlternateReportToURI' => 'https://example.net/csp/report-to',// for Reporting API reports
+            'DeliveryMethod' => Policy::POLICY_DELIVERY_METHOD_HEADER,
+            'MinimumCspLevel' => 2,
+        ]);
 
-        $check_policy = Policy::get()->byId($non_enabled_policy->ID);
+        $directive = $this->createDirective([
+            'Key' => 'font-src',
+            'Value' => '',
+            'RulesValue' => json_encode([ 'https://example.com' => '1', 'https://www.example.net' => '2', 'https://*.example.org' => '3' ]),
+            'IncludeSelf' => 1,
+            'UnsafeInline' => 0,
+            'AllowDataUri' => 1,
+            'Enabled' => 1,
+        ]);
 
-        $this->assertTrue($check_policy && $check_policy->IsBasePolicy == 1, 'New Base policy was not valid');
+        $policy->Directives()->add($directive);
+
+        $this->assertEquals($policy->Directives()->count(), 1);
+
+        $header = $policy->getPolicyData(true);
+
+        // Test report-uri
+        $policy_string = $header['policy_string'];
+        $this->assertStringContainsString(
+            "report-uri https://example.net/csp/report-uri",
+            $policy_string
+        );
+
+        // Test Reporting-Endpoints
+        $this->assertArrayHasKey(Policy::DEFAULT_REPORTING_GROUP, $header['reporting_endpoints']);
+        $this->assertEquals(
+            $header['reporting_endpoints'][ Policy::DEFAULT_REPORTING_GROUP ],
+            Policy::getReportingEndpoint(
+                Policy::DEFAULT_REPORTING_GROUP,
+                $policy->getReportingApiUrl()
+            )
+        );
+    }
+
+    public function testBasePolicyChange() {
+
+        $this->clearAllPolicies();
+
+        $policy = $this->createPolicy([
+            'Title' => 'Test Base Policy',
+            'Enabled' => 1,
+            'IsLive' => 1,
+            'IsBasePolicy' => 1,
+            'ReportOnly' => 0,
+            'SendViolationReports' => 1,
+            'EnableNEL' => 0, // NEL not enabled as not NEL reporting URL
+            'AlternateReportURI' => 'https://localhost/csp/reporting',
+            'DeliveryMethod' => Policy::POLICY_DELIVERY_METHOD_HEADER,
+            'MinimumCspLevel' => 1,
+        ]);
+
+        $base_policy = Policy::getDefaultBasePolicy();
+
+        $this->assertEquals($base_policy->ID, $policy->ID, "The base policy was not the expected policy");
+
+        // Create another policy, make it the base policy
+        $new_policy = $this->createPolicy([
+            'Title' => 'Test Policy',
+            'Enabled' => 1,
+            'IsLive' => 1,
+            'IsBasePolicy' => 1,
+            'ReportOnly' => 0,
+            'SendViolationReports' => 1,
+            'EnableNEL' => 0,
+            'AlternateReportURI' => 'https://localhost/csp/reporting',
+            'DeliveryMethod' => Policy::POLICY_DELIVERY_METHOD_HEADER,
+            'MinimumCspLevel' => 1,
+        ]);
+        $new_policy->write();
+
+        $base_policy = Policy::getDefaultBasePolicy();
+        $this->assertEquals($base_policy->ID, $new_policy->ID, "The base policy was not the new base policy");
+
     }
 
     public function testDirectives()
@@ -179,7 +253,7 @@ class PolicyTest extends SapphireTest
             'IsBasePolicy' => 1,
             'ReportOnly' => 0,
             'SendViolationReports' => 1,
-            'EnableNEL' => 1,
+            'EnableNEL' => 0,
             'AlternateReportURI' => '',
             'DeliveryMethod' => Policy::POLICY_DELIVERY_METHOD_HEADER,
             'MinimumCspLevel' => 1,
@@ -253,7 +327,7 @@ class PolicyTest extends SapphireTest
 
         $this->assertEquals($policy->Directives()->count(), count($directives));
 
-        $headers = $policy->HeaderValues(1, Policy::POLICY_DELIVERY_METHOD_HEADER);
+        $policyData = $policy->getPolicyData(true);
 
         /**
          * The CSP values should look like:
@@ -263,15 +337,16 @@ class PolicyTest extends SapphireTest
          * script-src 'self' 'unsafe-inline' https://media.example.com;
          * upgrade-insecure-requests;
          * report-uri http://localhost/csp/v1/report;
-         * report-to default;
+         * report-to csp-endpoint;
          */
 
-        $this->assertTrue(!empty($headers['header']) && $headers['header'] == Policy::HEADER_CSP);
-        $this->assertTrue(!empty($headers['reporting']));
-        $this->assertTrue(!empty($headers['nel']));
-        $this->assertTrue(!empty($headers['policy_string']));
+        $this->assertTrue(!empty($policyData['header']) && $policyData['header'] == Policy::HEADER_CSP);
+        $this->assertTrue(!empty($policyData['reporting_endpoints']));
+        $this->assertTrue(empty($policyData['nel']));
+        $this->assertTrue(empty($policyData['report_to']));
+        $this->assertTrue(!empty($policyData['policy_string']));
 
-        $formatted_values = Policy::parsePolicy($headers['policy_string']);
+        $formatted_values = Policy::parsePolicy($policyData['policy_string']);
 
         foreach ($formatted_values as $key => $value) {
             if (in_array($key, Directive::KeysWithoutValues())) {
@@ -328,7 +403,7 @@ class PolicyTest extends SapphireTest
             'IsBasePolicy' => 1,
             'ReportOnly' => 0,
             'SendViolationReports' => 1,
-            'EnableNEL' => 1,
+            'EnableNEL' => 0,
             'AlternateReportURI' => '',
             'DeliveryMethod' => Policy::POLICY_DELIVERY_METHOD_HEADER,
             'MinimumCspLevel' => 3,
@@ -345,17 +420,84 @@ class PolicyTest extends SapphireTest
         ]);
         $policy->Directives()->add($directive);
 
-        $headers = $policy->HeaderValues(1, Policy::POLICY_DELIVERY_METHOD_HEADER);
+        // policy should have a policy string
+        $policyData = $policy->getPolicyData(true);
+        $this->assertTrue(!empty($policyData['policy_string']));
 
-        $this->assertTrue(!empty($headers['policy_string']));
-
-        $formatted_values = Policy::parsePolicy($headers['policy_string']);
-
+        // report-uri should not be in the string
+        $formatted_values = Policy::parsePolicy($policyData['policy_string']);
         $this->assertTrue(!array_key_exists('report-uri', $formatted_values));
 
+        // report-to should be in the policy directives
         $this->assertTrue(
             array_key_exists('report-to', $formatted_values)
                     && $formatted_values['report-to'] == Policy::DEFAULT_REPORTING_GROUP
+        );
+
+        // test reporting endpoints is present
+        $this->assertEmpty($policyData['report_to']);// Report-To header is not present
+        $this->assertArrayHasKey(Policy::DEFAULT_REPORTING_GROUP, $policyData['reporting_endpoints']);
+        $this->assertEquals(
+            $policyData['reporting_endpoints'][ Policy::DEFAULT_REPORTING_GROUP ],
+            Policy::getReportingEndpoint(
+                Policy::DEFAULT_REPORTING_GROUP,
+                $policy->getReportingUrl()
+            )
+        );
+    }
+
+    public function testNEL()
+    {
+        $this->clearAllPolicies();
+
+        $policy = $this->createPolicy([
+            'Title' => 'Test Policy with NEL enabled',
+            'Enabled' => 1,
+            'IsLive' => 1,
+            'IsBasePolicy' => 1,
+            'ReportOnly' => 0,
+            'SendViolationReports' => 1,
+            'EnableNEL' => 1,
+            'AlternateReportURI' => 'https://csp.example.com/report',
+            'AlternateNELReportURI' => 'https://nel.example.com/report',
+            'DeliveryMethod' => Policy::POLICY_DELIVERY_METHOD_HEADER,
+            'MinimumCspLevel' => 3,
+        ]);
+
+        $directive = $this->createDirective([
+            'Key' => 'font-src',
+            'Value' => '',
+            'RulesValue' => json_encode(['https://font.example.com' => '', 'https://font.example.net' => '', 'https://*.font.example.org' => '']),
+            'IncludeSelf' => 1,
+            'UnsafeInline' => 0,
+            'AllowDataUri' => 1,
+            'Enabled' => 1,
+        ]);
+        $policy->Directives()->add($directive);
+
+        // policy should have a policy string
+        $policyData = $policy->getPolicyData(true);
+        $this->assertTrue(!empty($policyData['policy_string']));
+
+        // report-uri should not be in the string
+        $formatted_values = Policy::parsePolicy($policyData['policy_string']);
+        $this->assertTrue(!array_key_exists('report-uri', $formatted_values));
+
+        // report-to should be in the policy directives
+        $this->assertTrue(
+            array_key_exists('report-to', $formatted_values)
+                    && $formatted_values['report-to'] == Policy::DEFAULT_REPORTING_GROUP
+        );
+
+        // test reporting endpoints is present
+        $this->assertNotEmpty($policyData['report_to']);// Report-To header is present
+        $this->assertArrayHasKey(Policy::DEFAULT_REPORTING_GROUP, $policyData['reporting_endpoints']);
+        $this->assertEquals(
+            $policyData['reporting_endpoints'][ Policy::DEFAULT_REPORTING_GROUP ],
+            Policy::getReportingEndpoint(
+                Policy::DEFAULT_REPORTING_GROUP,
+                $policy->getReportingUrl()
+            )
         );
     }
 }


### PR DESCRIPTION
## Changes

+ Update reporting headers (Report-To > Reporting-Endpoints) based on browser support changes
+ Allow split report-uri / report-to URLs for reporting services
+ Split NEL option from CSP handling